### PR TITLE
Fix for Slow Query Logging on 5.1.29

### DIFF
--- a/lib/moonshine/manifest/rails/templates/moonshine.cnf.erb
+++ b/lib/moonshine/manifest/rails/templates/moonshine.cnf.erb
@@ -58,7 +58,14 @@ thread_stack          = <%= configuration[:mysql][:thread_stack] || '192K' %>
 transaction_isolation = <%= configuration[:mysql][:transaction_isolation] || 'READ-COMMITTED' %>
 tmp_table_size        = <%= configuration[:mysql][:tmp_table_size] || '128M' %>
 tmpdir                = <%= configuration[:mysql][:tmpdir] || '/tmp' %>
-<%= configuration[:mysql][:version] > 5 ? 'slow_query_log' : 'log_slow_queries' %>      = <%= configuration[:mysql][:log_slow_queries] || '/var/log/mysql/slow_queries.log' %>
+<% if configuration[:mysql][:version] > 5 %>
+slow_query_log        = <%= configuration[:mysql][:disable_slow_query_log] ? 0 : 1 %>
+slow_query_log_file   = <%= configuration[:mysql][:log_slow_queries] || '/var/log/mysql/slow_queries.log' %>
+<% else %>
+<% unless configuration[:mysql][:disable_slow_query_log] %>
+log_slow_queries      = <%= configuration[:mysql][:log_slow_queries] || '/var/log/mysql/slow_queries.log' %>
+<% end %>
+<% end %>
 long_query_time       = <%= configuration[:mysql][:long_query_time] || '5' %>
 
 <%= configuration[:mysql][:extra] %>


### PR DESCRIPTION
http://dev.mysql.com/doc/refman/5.1/en/slow-query-log.html

As of MySQL 5.1.29, use --slow_query_log[={0|1}] to enable or disable the slow query log, and optionally --slow_query_log_file=file_name to specify a log file name

Updated cnf file to use new syntax, plus a new option to :disable_slow_query_log

Note: not tested on 5.0
Note2: I don't know how to send a pull request with JUST the final good commit without my 2 reverts :]
