### PR TITLE
Fix cap app:console on Rails 3

### DIFF
--- a/lib/moonshine/capistrano_integration.rb
+++ b/lib/moonshine/capistrano_integration.rb
@@ -180,12 +180,12 @@ module Moonshine
           desc 'Run script/console on the first application server'
           task :console, :roles => :app, :except => {:no_symlink => true} do
             input = ''
-            if fetch(:rails_version) >= 3
-              command = "cd #{current_path} && rails console #{fetch(:rails_env)}"
-              prompt = /:\d{3}:\d+(\*|>)/
-            else
+            if capture("test -f #{current_path}/script/console; echo $?").strip == "0"
               command = "cd #{current_path} && ./script/console #{fetch(:rails_env)}"
               prompt = /^(>|\?)>/
+            else
+              command = "cd #{current_path} && rails console #{fetch(:rails_env)}"
+              prompt = /:\d{3}:\d+(\*|>)/
             end
             run command do |channel, stream, data|
               next if data.chomp == input.chomp || data.chomp == ''


### PR DESCRIPTION
This tells cap app:console to use 'rails console' instead of 'script/console' on Rails 3 or greater. It also sets the appropriate prompt detection regex for the "streaming capistrano" hack (the prompt on Rails 3 is different so the console would freeze after entering a statement).

I couldn't figure out a good way to get the Rails version from within capistrano_integration.rb, so I added an optional configuration variable "rails_version" to moonshine.yml. It defaults to 2 so that the current behavior does not change at all on existing Moonshine installs. The moonshine.yml generator sets the default rails_version to 2, but it would probably be possible to set it based on Rails::VERSION::MAJOR.

This is tested and working on a live install.
