### PR TITLE
Fix Rails 3 app:console (updated)

### DIFF
--- a/lib/moonshine/capistrano_integration.rb
+++ b/lib/moonshine/capistrano_integration.rb
@@ -184,7 +184,7 @@ module Moonshine
               command = "cd #{current_path} && ./script/console #{fetch(:rails_env)}"
               prompt = /^(>|\?)>/
             else
-              command = "cd #{current_path} && rails console #{fetch(:rails_env)}"
+              command = "cd #{current_path} && ./script/rails console #{fetch(:rails_env)}"
               prompt = /:\d{3}:\d+(\*|>)/
             end
             run command do |channel, stream, data|


### PR DESCRIPTION
The server I tested my fix on before had the rails executable in the PATH. Default Moonshine installs do not, so I've changed the command to use ./script/rails instead of the rails executable. Tested and working on a virgin Moonshine install. Sorry about that! 
