### PR TITLE
Update Ruby Enterprise Edition to 1.8.7-2011.01

### DIFF
--- a/lib/moonshine/capistrano_integration.rb
+++ b/lib/moonshine/capistrano_integration.rb
@@ -391,11 +391,11 @@ module Moonshine
             remove_ruby_from_apt
             run [
               'cd /tmp',
-              'sudo rm -rf ruby-enterprise-1.8.7-2010.02* || true',
+              'sudo rm -rf ruby-enterprise-1.8.7-2011.01* || true',
               'sudo mkdir -p /usr/lib/ruby/gems/1.8/gems || true',
-              'wget -q http://rubyforge.org/frs/download.php/71096/ruby-enterprise-1.8.7-2010.02.tar.gz',
-              'tar xzf ruby-enterprise-1.8.7-2010.02.tar.gz',
-              'sudo /tmp/ruby-enterprise-1.8.7-2010.02/installer --dont-install-useful-gems --no-dev-docs -a /usr'
+              'wget -q http://rubyenterpriseedition.googlecode.com/files/ruby-enterprise-1.8.7-2011.01.tar.gz',
+              'tar xzf ruby-enterprise-1.8.7-2011.01.tar.gz',
+              'sudo /tmp/ruby-enterprise-1.8.7-2011.01/installer --dont-install-useful-gems --no-dev-docs -a /usr'
             ].join(' && ')
           end
 


### PR DESCRIPTION
Released today: http://blog.phusion.nl/2011/02/12/ruby-enterprise-edition-1-8-7-2011-01-released/

Tested and working on a live install.
