### PR TITLE
Add UnionStation support

### DIFF
--- a/lib/moonshine/manifest/rails/templates/passenger.vhost.erb
+++ b/lib/moonshine/manifest/rails/templates/passenger.vhost.erb
@@ -161,6 +161,20 @@
   PassengerPreStart <%= configuration[:passenger][:pre_start_url] %>
   <% end %>
 
+  ## Phusion UnionStation support
+  #
+  # http://www.unionstationapp.com/
+  #
+  # On Rails 3, you will also need to add config/initializers/passenger.rb
+  # with the following line:
+  #
+  # PhusionPassenger.install_framework_extensions! if defined?(PhusionPassenger)
+
+  <% if configuration[:passenger][:union_station_key] %>
+  UnionStationSupport on
+  UnionStationKey <%= configuration[:passenger][:union_station_key] %>
+  <% end %>
+
   # Deflate
   <IfModule mod_deflate.c>
     AddOutputFilterByType DEFLATE <%= configuration[:apache][:gzip_types].join(' ') %>
@@ -371,6 +385,20 @@
 
   <% if configuration[:passenger][:pre_start_url] %>
   PassengerPreStart <%= configuration[:passenger][:pre_start_url] %>
+  <% end %>
+
+  ## Phusion UnionStation support
+  #
+  # http://www.unionstationapp.com/
+  #
+  # On Rails 3, you will also need to add config/initializers/passenger.rb
+  # with the following line:
+  #
+  # PhusionPassenger.install_framework_extensions! if defined?(PhusionPassenger)
+
+  <% if configuration[:passenger][:union_station_key] %>
+  UnionStationSupport on
+  UnionStationKey <%= configuration[:passenger][:union_station_key] %>
   <% end %>
 
   # Deflate


### PR DESCRIPTION
I figure since this is an official Phusion thing that is baked into the blessed version of Passenger, it might be worth putting into the vhost config. If not, people can just put it in vhost_extra but I figured I'd leave that decision up to the maintainers.

This goes in moonshine.yml:

```
:passenger:
  :union_station_key: abcd1234
```

On Rails 3, you need a 1-line config/initializers/passenger.rb, which I've put in the comments.
