### PR TITLE
Bad template means SSL and non-SSL run different environments.

### DIFF
--- a/lib/moonshine/manifest/rails/templates/passenger.vhost.erb
+++ b/lib/moonshine/manifest/rails/templates/passenger.vhost.erb
@@ -307,21 +307,19 @@
   # RailsAllowModRewrite is deprecated. Passenger supports mod_rewrite by default now. configure(:passenger => { :allow_mod_rewrite => true/false }) if you still wish to use it.
   <% end %>
 
-<% if rails_root.join('config.ru').exist? %>
   ## RackEnv
   #
   # Use this option to specify the default RACK_ENV value. The default
   # setting is production.
 
-  RackEnv <%= configuration[:passenger][:rack_env] || ENV['RACK_ENV'] || 'production' %>
-<% else %>
+  RackEnv <%= configuration[:passenger][:rails_env] || ENV['RAILS_ENV'] || 'production' %>
+
   ## RailsEnv
   #
   # Use this option to specify the default RAILS_ENV value. The default
   # setting is production.
 
   RailsEnv <%= configuration[:passenger][:rails_env] || ENV['RAILS_ENV'] || 'production' %>
-<% end %>
 
   ## RailsSpawnMethod
   #


### PR DESCRIPTION
"That's strange... why are my SSL requests getting the production asset host on staging? Oh, because my vhost looks like this!"

<pre>&lt;VirtualHost *:80&gt;

  ## RackEnv
  #
  # Use this option to specify the default RACK_ENV value. The default
  # setting is production.

  RackEnv staging

  ## RailsEnv
  #
  # Use this option to specify the default RAILS_ENV value. The default
  # setting is production.

  RailsEnv staging

&lt;/VirtualHost&gt;

&lt;VirtualHost _default_:443&gt;

  ## RackEnv
  #
  # Use this option to specify the default RACK_ENV value. The default
  # setting is production.

  RackEnv production

&lt;/VirtualHost&gt;</pre>


The SSL and non-SSL sections of the template got out of sync. I've tried to figure out [who to blame](https://github.com/jgarber/moonshine/blame/master/lib/moonshine/manifest/rails/templates/passenger.vhost.erb) and can't come up with anyone. :)

The SSL section checks for config.ru and uses :rack_env. Looks like that was removed in df8470268d55c9aadd1bb9f593e638543bf42007, so I copied it to the SSL section.

So, that's fixed for now, but **somebody please DRY up that template!!**
