### PR TITLE
Fixes leading space in rake when there is no Gemfile.

### DIFF
--- a/lib/moonshine/manifest/rails/rails.rb
+++ b/lib/moonshine/manifest/rails/rails.rb
@@ -267,9 +267,9 @@ module Moonshine::Manifest::Rails::Rails
   # Creates exec("rake #name") that runs in <tt>rails root</tt> of the rails
   # app, with RAILS_ENV properly set
   def rake(name, options = {})
-    exec("#{try_bundle_exec} rake #{name}", {
-      :command => "#{try_bundle_exec} rake #{name}",
-      :alias => "rake#{name}",
+    exec("#{try_bundle_exec}rake #{name}", {
+      :command => "#{try_bundle_exec}rake #{name}",
+      :alias => "rake #{name}",
       :user => configuration[:user],
       :cwd => rails_root,
       :environment => "RAILS_ENV=#{ENV['RAILS_ENV']}",


### PR DESCRIPTION
If there is no Gemfile, the rake enviroment command is excuted as " rake environment" (with the quotes)
This fails because of the leading space.

When deploying, the error looked like this:
err: /Exec[ rake environment --trace]/returns: change from notrun to 0 failed: Could not find command ''
