### PR TITLE
Bump REE version to 1.8.7-2011.12

### DIFF
--- a/lib/moonshine/capistrano_integration.rb
+++ b/lib/moonshine/capistrano_integration.rb
@@ -397,11 +397,11 @@ module Moonshine
             remove_ruby_from_apt
             run [
               'cd /tmp',
-              'sudo rm -rf ruby-enterprise-1.8.7-2011.03* || true',
+              'sudo rm -rf ruby-enterprise-1.8.7-2011.12* || true',
               'sudo mkdir -p /usr/lib/ruby/gems/1.8/gems || true',
-              'wget -q http://rubyenterpriseedition.googlecode.com/files/ruby-enterprise-1.8.7-2011.03.tar.gz',
-              'tar xzf ruby-enterprise-1.8.7-2011.03.tar.gz',
-              'sudo /tmp/ruby-enterprise-1.8.7-2011.03/installer --dont-install-useful-gems --no-dev-docs -a /usr'
+              'wget -q http://rubyenterpriseedition.googlecode.com/files/ruby-enterprise-1.8.7-2011.12.tar.gz',
+              'tar xzf ruby-enterprise-1.8.7-2011.12.tar.gz',
+              'sudo /tmp/ruby-enterprise-1.8.7-2011.12/installer --dont-install-useful-gems --no-dev-docs -a /usr'
             ].join(' && ')
           end
 


### PR DESCRIPTION
Update REE to 1.8.7-2011.12 so that it includes the patch for the hash table denial of service attacks.
