### PR TITLE
Install activesupport 3.1.3 prior to shadow_puppet to avoid installing a...

### DIFF
--- a/lib/moonshine/capistrano_integration.rb
+++ b/lib/moonshine/capistrano_integration.rb
@@ -455,6 +455,7 @@ module Moonshine
           end
 
           task :install_moonshine_deps do
+            sudo 'gem install activesupport --version "~> 3.1.3"' 
             sudo 'gem install rake --no-rdoc --no-ri'
             sudo 'gem install i18n --no-rdoc --no-ri' # workaround for missing activesupport-3.0.2 dep on i18n
             sudo 'gem install shadow_puppet --no-rdoc --no-ri --version "~> 0.5.0"'


### PR DESCRIPTION
...ctivesupport 3.2.0.  3.2.0 breaks deploy:setup.
