### PR TITLE
Speed up deploys by issuing fewer commands

### DIFF
--- a/lib/moonshine/capistrano_integration.rb
+++ b/lib/moonshine/capistrano_integration.rb
@@ -303,15 +303,18 @@ module Moonshine
   Symlinks uploaded local configurations into the release directory.
           DESC
           task :symlink do
+            dirs, links = [], []
             fetch(:shared_config).each do |file|
               file = Pathname.new(file)
 
               filename = file.basename
               directory = file.dirname
+              dirs << directory
 
-              run "mkdir -p '#{latest_release}/#{directory}'"
-              run "ls #{latest_release}/#{file} 2> /dev/null || ln -nfs #{shared_path}/#{directory}/#{filename} #{latest_release}/#{file}"
+              links << "ls #{latest_release}/#{file} 2> /dev/null || ln -nfs #{shared_path}/#{directory}/#{filename} #{latest_release}/#{file}"
             end
+            run "mkdir -p " + dirs.uniq.map {|dir| "'#{latest_release}/#{dir}'"}.join(" ")
+            run links.map {|l| "(#{l})"}.join(" && ")
           end
         end
 


### PR DESCRIPTION
lets batch these config file symlinks and push them as one command just like capistrano does for shared_children
