### PR TITLE
Added application/json to gzip_types

### DIFF
--- a/lib/moonshine/manifest/rails/apache.rb
+++ b/lib/moonshine/manifest/rails/apache.rb
@@ -9,7 +9,7 @@ module Moonshine::Manifest::Rails::Apache
       :timeout => 300,
       :trace_enable => 'On',
       :gzip => false,
-      :gzip_types => ['text/html', 'text/plain', 'text/xml', 'text/css', 'application/x-javascript', 'application/javascript']
+      :gzip_types => ['text/html', 'text/plain', 'text/xml', 'text/css', 'application/x-javascript', 'application/javascript', 'application/json']
     }
   end
 


### PR DESCRIPTION
Because it should be compressed if possible (especially if it's going to a browser).
