### PR TITLE
Bump src193 patch level to p194

### DIFF
--- a/lib/moonshine/capistrano_integration.rb
+++ b/lib/moonshine/capistrano_integration.rb
@@ -449,7 +449,7 @@ module Moonshine
 
           task :src193 do
             remove_ruby_from_apt
-            pv = "1.9.3-p125"
+            pv = "1.9.3-p194"
             p = "ruby-#{pv}"
             run [
               'cd /tmp',


### PR DESCRIPTION
Updated my app to 1.9.3 today and noticed moonshine was at p125 and newest is p194 (http://www.ruby-lang.org/en/news/2012/04/20/ruby-1-9-3-p194-is-released/).

I know this is the smallest change ever but thought it may be helpful anyways.
