### PR TITLE
Bump src193 patchlevel up to 1.9.3-p392 [FIXED]

### DIFF
--- a/lib/moonshine/capistrano_integration.rb
+++ b/lib/moonshine/capistrano_integration.rb
@@ -541,7 +541,7 @@ module Moonshine
 
           task :src193 do
             remove_ruby_from_apt
-            pv = "1.9.3-p327"
+            pv = "1.9.3-p392"
             p = "ruby-#{pv}"
             run [
               'cd /tmp',


### PR DESCRIPTION
This Ruby patch takes care of some of the recent vulnerabilities (JSON parsing and XML denial of service).

More info here:
http://www.ruby-lang.org/en/news/2013/02/22/ruby-1-9-3-p392-is-released/

(This one has the correct patchlevel)
