### PR TITLE
Turns gzip on by default, updates gzip_types.

### DIFF
--- a/lib/moonshine/manifest/rails/apache.rb
+++ b/lib/moonshine/manifest/rails/apache.rb
@@ -13,8 +13,8 @@ module Moonshine::Manifest::Rails::Apache
       :max_requests_per_child => 0,
       :timeout => 300,
       :trace_enable => 'On',
-      :gzip => false,
-      :gzip_types => ['text/html', 'text/plain', 'text/xml', 'text/css', 'application/x-javascript', 'application/javascript', 'application/json']
+      :gzip => true,
+      :gzip_types => ['text/html', 'text/plain', 'text/xml', 'text/css', 'text/javascript', 'text/json', 'application/x-javascript', 'application/javascript', 'application/json']
     }
   end
 


### PR DESCRIPTION
Because having gzip turned on by default is the right thing to do.  The gzip_types list was also missing some common variations on javascript MIME types.
