### PR TITLE
Add postgres hstore recipe for adding hstore module to postgres 8.4/8.3

### DIFF
--- a/lib/moonshine/manifest/rails/postgresql.rb
+++ b/lib/moonshine/manifest/rails/postgresql.rb
@@ -68,6 +68,13 @@ module Moonshine::Manifest::Rails::Postgresql
       :notify   => exec('rails_bootstrap')
   end
 
+  # Include contrib module
+  def postgresql_hstore
+    exec "postgresql_hstore",
+      :command => "/usr/bin/psql -U postgres -d #{database_environment[:database]} -f /usr/share/postgresql/#{postgresql_version}/contrib/hstore.sql",
+      :user => 'postgres'
+  end
+
 private
 
   def psql(query, options = {})

--- a/spec/moonshine/manifest/rails_spec.rb
+++ b/spec/moonshine/manifest/rails_spec.rb
@@ -450,6 +450,21 @@ describe Moonshine::Manifest::Rails do
     @manifest.should exec_command('/usr/bin/createdb -O pg_username pg_database')
   end
 
+  specify "#postgresql_hstore" do
+    @manifest.should_receive(:postgresql_version).and_return('8.4')
+    @manifest.should_receive(:database_environment).at_least(:once).and_return({
+      :username => 'pg_username',
+      :database => 'pg_database',
+      :password => 'pg_password'
+    })
+
+    @manifest.postgresql_server
+    @manifest.postgresql_user
+    @manifest.postgresql_database
+
+    @manifest.should exec_command('/usr/bin/psql -U postgres -d pg_database -f /usr/share/postgresql/8.4/contrib/hstore.sql')
+  end
+
   describe "#gem" do
     before do
       @manifest.gem 'rmagick'


### PR DESCRIPTION
Add postgres hstore recipe for adding hstore module to postgres 8.4/8.3

As a workaround to the current implementation restricting use of hstore due to the need to manually load contrib modules in 8.4, I've added a recipe to install this for you.
