### PR TITLE
Fix ruby patches upload path for railsexpress patches.

### DIFF
--- a/lib/moonshine/capistrano_integration.rb
+++ b/lib/moonshine/capistrano_integration.rb
@@ -586,7 +586,7 @@ module Moonshine
             set :ruby_patches_path, rails_root.join('vendor', 'plugins', 'moonshine', 'patches')
             if ruby_patches_path.exist?
               run 'mkdir -p /tmp/moonshine'
-              upload ruby_patches_path.to_s, "/tmp/moonshine/patches", :via => :scp, :recursive => true
+              upload ruby_patches_path.to_s, "/tmp/moonshine/", :via => :scp, :recursive => true
             end
             remove_ruby_from_apt
             pv = "1.9.3-p484"
@@ -645,7 +645,7 @@ module Moonshine
             set :ruby_patches_path, rails_root.join('vendor', 'plugins', 'moonshine', 'patches')
             if ruby_patches_path.exist?
               run 'mkdir -p /tmp/moonshine'
-              upload ruby_patches_path.to_s, "/tmp/moonshine/patches", :via => :scp, :recursive => true
+              upload ruby_patches_path.to_s, "/tmp/moonshine/", :via => :scp, :recursive => true
             end
             remove_ruby_from_apt
             pv = "2.0.0-p353"


### PR DESCRIPTION
Files would correctly be uploaded to `/tmp/moonshine/patches/` on the first upload, but subsequent uploads would go into the `/tmp/moonshine/patches/patches/` directory.  This would cause errors for instance, when you uploaded the patches once for 1.9.3 before the 2.0.0 patches were available.  Then when upgrading to 2.0.0, all patches would be in the nested patches directory and not the main patches directory.  The 2.0.0 patches wouldn't be reached as the 1.9.3 patches are the only patches in the intended location.  This fixes the problem.
