### PR TITLE
Fix grant syntax quoting

### DIFF
--- a/lib/moonshine/manifest/rails/mysql.rb
+++ b/lib/moonshine/manifest/rails/mysql.rb
@@ -42,7 +42,7 @@ module Moonshine::Manifest::Rails::Mysql
     grant =<<EOF
 GRANT ALL PRIVILEGES
 ON #{database_environment[:database]}.*
-TO #{database_environment[:username]}@localhost
+TO \\"#{database_environment[:username]}\\"@\\"localhost\\"
 IDENTIFIED BY \\"#{database_environment[:password]}\\";
 FLUSH PRIVILEGES;
 EOF


### PR DESCRIPTION
In all the MySQL documentation I've seen--and all my personal experience--the TO clause of a GRANT statement must have the username and host quoted as:

'user'@'localhost'

rather than:

user@localhost

...the latter seems to cause a syntax error.
