### PR TITLE
Adds support for brightbox ppa-provided Ruby 1.9.3 and 2.1.2

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -64,12 +64,22 @@ We've added support for Passenger Enterprise Edition!  In order to install it, y
 
 This is what a passenger enterprise block in moonshine.yml should look like (in addition to your usual Passenger settings):
 
-    :passenger:
-      :version: 4.0.10
-      :enterprise: true
-      :download_token: YOUR-PASSENGER-ENTERPRISE-DOWNLOAD-TOKEN
-      :rolling_restarts: true
-    
+```yaml
+:passenger:
+  :version: 4.0.10
+  :enterprise: true
+  :download_token: YOUR-PASSENGER-ENTERPRISE-DOWNLOAD-TOKEN
+  :rolling_restarts: true
+```
+
+## Brightbox Ruby
+
+Compiling ruby from source is time and CPU consuming.  In an attempt to speed up ruby upgrades and make it easier to roll back to the previous version, we've added support for [Brightbox's Ruby packages](http://brightbox.com/docs/ruby/ubuntu/). Setting it up is easy, just set the ruby line in config/moonshine.yml to <code>brightbox193</code> or <code>brightbox21</code>.
+
+### Limitations
+
+* **Ubuntu 10.04**: Brightbox doesn't provide packages for Ruby 2.1.2.  If you want it, you'll need to upgrade to at least 12.04.
+  
 ## A Word on Rails 4
 
 We've been torturing ourselves trying to turn Moonshine into a gem ever since it was announced that Rails 4 was dropping support for plugins.  Moonshine is... different... and we think it actually makes sense as a plugin.  So, instead of turning Moonshine, and the dozens of Moonshine plugins we've written, into a gem, we decided to add plugin support back to Rails 4!  That's where [plugger](http://github.com/railsmachine/plugger) comes in. Just add it to your Gemfile and <code>bundle install</code> and voila, plugins are *back*!
@@ -78,9 +88,11 @@ We've been torturing ourselves trying to turn Moonshine into a gem ever since it
 
 By default, everything within the app directory is eager-loaded by the app at startup in production mode (and staging).  That's not good.  So, to keep that from happening, add this to config/application.rb inside the Application class:
 
-<pre><code>path_rejector = lambda { |s| s.include?("app/manifests") }
+```ruby
+path_rejector = lambda { |s| s.include?("app/manifests") }
 config.eager_load_paths = config.eager_load_paths.reject(&path_rejector)
-ActiveSupport::Dependencies.autoload_paths.reject!(&path_rejector)</code></pre>
+ActiveSupport::Dependencies.autoload_paths.reject!(&path_rejector)
+```
 
 That'll keep the manifests from loading when the app starts up!
 
@@ -88,8 +100,10 @@ That'll keep the manifests from loading when the app starts up!
 
 With Rails 4, it doesn't want you to use the <code>--binstubs</code> argument for bundler, so it's now optional.  If you're using Moonshine and Rails 4, add this to config/moonshine.yml, and you'll be all set:
 
-<pre><code>:bundler:
-  :disable_binstubs: true</code></pre>
+```yaml
+:bundler:
+  :disable_binstubs: true
+```
   
 After your next deploy, you should be able to run rails console without that annoying error message.
 

--- a/lib/moonshine/capistrano_integration.rb
+++ b/lib/moonshine/capistrano_integration.rb
@@ -604,6 +604,55 @@ module Moonshine
             ].join(' && ')
           end
 
+          task :brightbox21 do
+            remove_ruby_from_apt
+            run [
+              'sudo rm -f /usr/bin/ruby',
+              'sudo rm -f /usr/bin/gem',
+              'sudo rm -f /usr/bin/rake',
+              'sudo rm -f /usr/bin/rdoc',
+              'sudo rm -f /usr/bin/irb',
+              'sudo rm -f /usr/bin/erb',
+              'sudo rm -f /usr/bin/ri',
+              'sudo rm -f /usr/bin/testrb',
+              'sudo apt-get install python-software-properties software-properties-common -y',
+              'sudo apt-add-repository ppa:brightbox/ruby-ng -y',
+              'sudo apt-get update',
+              'sudo apt-get install ruby2.1 ruby2.1-dev -y'
+            ].join(' && ')
+            set :rubygems_version, fetch(:rubygems_version, '2.2.2')
+            set :bundler_version, fetch(:bundler_version, '1.6.2')
+          end
+
+          task :brightbox193 do
+            remove_ruby_from_apt
+    
+            version = capture("lsb_release -r").split(":").last.to_f
+    
+            repo_flag = ""
+            software_properties = "python-software-properties"
+    
+            if version >= 12
+              repo_flag = "-y"
+              software_properties << " software-properties-common"
+            end
+    
+            run [
+              'sudo rm -f /usr/bin/ruby',
+              'sudo rm -f /usr/bin/gem',
+              'sudo rm -f /usr/bin/rake',
+              'sudo rm -f /usr/bin/rdoc',
+              'sudo rm -f /usr/bin/irb',
+              'sudo rm -f /usr/bin/erb',
+              'sudo rm -f /usr/bin/ri',
+              'sudo rm -f /usr/bin/testrb',
+              "sudo apt-get install #{software_properties} -y",
+              "sudo apt-add-repository ppa:brightbox/ruby-ng #{repo_flag}",
+              'sudo apt-get update',
+              'sudo apt-get install build-essential ruby1.9.1 ruby1.9.1-dev -y'
+            ].join(' && ')
+          end
+
           task :src187 do
             remove_ruby_from_apt
             run [


### PR DESCRIPTION
Adds support for installing ruby from the Brightbox PPA instead of compiling from source.

Tested with 10.04, 12.04 and 14.04 and moving from source-compiled ruby to the packages and vice versa.
