### PR TITLE
Fix ruby src21railsexpress task

### DIFF
--- a/lib/moonshine/capistrano_integration.rb
+++ b/lib/moonshine/capistrano_integration.rb
@@ -840,16 +840,6 @@ module Moonshine
             remove_ruby_from_apt
             libyaml.install
             sudo 'apt-get install autoconf -y || true',
-            patches = [
-              "patch -p1 </tmp/moonshine/patches/ruby/2.1.5/railsexpress/01-zero-broken-tests.patch",
-              "patch -p1 </tmp/moonshine/patches/ruby/2.1.5/railsexpress/02-improve-gc-stats.patch",
-              "patch -p1 </tmp/moonshine/patches/ruby/2.1.5/railsexpress/03-display-more-detailed-stack-trace.patch",
-              "patch -p1 </tmp/moonshine/patches/ruby/2.1.5/railsexpress/04-show-full-backtrace-on-stack-overflow.patch",
-              "patch -p1 </tmp/moonshine/patches/ruby/2.1.5/railsexpress/05-funny-falcon-stc-density.patch",
-              "patch -p1 </tmp/moonshine/patches/ruby/2.1.5/railsexpress/06-funny-falcon-stc-pool-allocation.patch",
-              "patch -p1 </tmp/moonshine/patches/ruby/2.1.5/railsexpress/07-aman-opt-aset-aref-str.patch",
-              "patch -p1 </tmp/moonshine/patches/ruby/2.1.5/railsexpress/08-funny-falcon-method-cache.patch"
-            ]
             pv = "2.1.5"
             p = "ruby-#{pv}"
             run [
@@ -861,9 +851,16 @@ module Moonshine
               'sudo mkdir -p /usr/lib/ruby/gems/2.1.0/gems || true',
               "wget -q http://cache.ruby-lang.org/pub/ruby/2.1/#{p}.tar.gz",
               "tar xzf #{p}.tar.gz",
-              "cd /tmp/#{p}"]
-              +patches+
-              ['./configure --prefix=/usr',
+              "cd /tmp/#{p}",
+              "patch -p1 </tmp/moonshine/patches/ruby/2.1.5/railsexpress/01-zero-broken-tests.patch",
+              "patch -p1 </tmp/moonshine/patches/ruby/2.1.5/railsexpress/02-improve-gc-stats.patch",
+              "patch -p1 </tmp/moonshine/patches/ruby/2.1.5/railsexpress/03-display-more-detailed-stack-trace.patch",
+              "patch -p1 </tmp/moonshine/patches/ruby/2.1.5/railsexpress/04-show-full-backtrace-on-stack-overflow.patch",
+              "patch -p1 </tmp/moonshine/patches/ruby/2.1.5/railsexpress/05-funny-falcon-stc-density.patch",
+              "patch -p1 </tmp/moonshine/patches/ruby/2.1.5/railsexpress/06-funny-falcon-stc-pool-allocation.patch",
+              "patch -p1 </tmp/moonshine/patches/ruby/2.1.5/railsexpress/07-aman-opt-aset-aref-str.patch",
+              "patch -p1 </tmp/moonshine/patches/ruby/2.1.5/railsexpress/08-funny-falcon-method-cache.patch",
+              './configure --prefix=/usr',
               'make',
               'sudo make install'
             ].join(' && ')


### PR DESCRIPTION
Separate array for patches is no longer needed.
I received `undefined method 'strip' for Array` errors from capistrano when trying to upgrade from 2.1.2-railsexpress to 2.1.5-railsexpress.  This change prevents the problem.