### PR TITLE
Update mysql_version to a valid version on trusty

### DIFF
--- a/lib/moonshine/manifest/rails/mysql.rb
+++ b/lib/moonshine/manifest/rails/mysql.rb
@@ -105,7 +105,7 @@ private
   def mysql_version
     if ubuntu_lucid?
       5.1
-    elsif ubuntu_precise?
+    elsif ubuntu_precise? || ubuntu_trusty?
       5.5
     else
       5.0

--- a/lib/moonshine/manifest/rails/templates/moonshine.cnf.erb
+++ b/lib/moonshine/manifest/rails/templates/moonshine.cnf.erb
@@ -14,7 +14,7 @@ collation_server        = <%= configuration[:mysql][:collation_server] || 'utf8_
 ######### replication
 server-id                = <%= configuration[:mysql][:server_id] || '1' %>
 auto-increment-increment = <%= configuration[:mysql][:auto_increment_increment] || '10' %>
-auto-increment-offset    = <%= configuration[:mysql][:auto_increment_offset] || configuration[:mysql][:server_id] || '1' %><% if configuration[:mysql][:version] > 5 or ubuntu_trusty? %>
+auto-increment-offset    = <%= configuration[:mysql][:auto_increment_offset] || configuration[:mysql][:server_id] || '1' %><% if configuration[:mysql][:version] > 5 %>
 binlog_format            = mixed<% end %>
 log-bin                  = <%= configuration[:mysql][:log_bin] || "#{log_prefix}-bin" %>
 log-bin-index            = <%= configuration[:mysql][:log_bin_index] || "#{log_prefix}-bin" %>


### PR DESCRIPTION
This allows the other conditional on the mysql version in the configuration template to use the desired statements (regarding the slow query log) as well.