### PR TITLE
Add python-software-properties package to default config.

### DIFF
--- a/lib/moonshine/manifest/rails.rb
+++ b/lib/moonshine/manifest/rails.rb
@@ -55,7 +55,7 @@ class Moonshine::Manifest::Rails < Moonshine::Manifest
       recipe :sqlite3
     end
     recipe :rails_rake_environment, :rails_gems, :rails_directories, :rails_bootstrap, :rails_migrations, :rails_logrotate
-    recipe :ntp, :time_zone, :postfix, :cron_packages, :motd, :security_updates, :apt_sources, :hostname
+    recipe :ntp, :time_zone, :postfix, :cron_packages, :motd, :security_updates, :apt_sources, :python_software_properties, :hostname
 
     if precompile_asset_pipeline?
       recipe :rails_asset_pipeline

--- a/lib/moonshine/manifest/rails/os.rb
+++ b/lib/moonshine/manifest/rails/os.rb
@@ -267,6 +267,22 @@ CONFIG
     end
   end
 
+  #### Python Software Properties
+
+  # The python-software-properties (and software-properties-common on Ubuntu 14.04
+  # provides utilities for working with third party PPAs and Apt repos.
+
+  def python_software_properties
+    if ubuntu_trusty?
+      package 'software-properties-common',
+        :alias => 'python-software-properties',
+        :ensure => :installed
+    else
+      package 'python-software-properties',
+        :ensure => :installed
+    end
+  end
+
   #### Packages
 
   # We Override the `shadow_puppet` package method to inject a dependency on


### PR DESCRIPTION
The `python-software-properties` package is used by several moonshine
plugins causing an issue of the package being defined multiple times.
By including it by default in moonshine itself we can remove those
definitions from the other plugins and just add a `:require` as needed.