### PR TITLE
Fix Bundler#dependencies_for removal in recent Bundler versions.

### DIFF
--- a/lib/moonshine/manifest/rails/rails.rb
+++ b/lib/moonshine/manifest/rails/rails.rb
@@ -109,7 +109,7 @@ module Moonshine::Manifest::Rails::Rails
                   else
                    Bundler.load
                   end
-        bundler_dependencies = bundler.dependencies_for(:default, rails_env.to_sym)
+        bundler_dependencies = bundler.dependencies.select {|d| ([:default, rails_env.to_sym] & d.groups).any? }
         bundler_dependencies.each do |dependency|
           system_dependencies = configuration[:apt_gems][dependency.name.to_s] || []
           system_dependencies.each do |system_dependency|


### PR DESCRIPTION
Signed-off-by: Bryan Traywick <bryantraywick@gmail.com>