### PR TITLE
Update Ruby, RubyGems, and Bundler

### DIFF
--- a/lib/moonshine/capistrano_integration.rb
+++ b/lib/moonshine/capistrano_integration.rb
@@ -722,7 +722,7 @@ module Moonshine
               'sudo make install'
             ].join(' && ')
             set :rubygems_version, fetch(:rubygems_version, '2.4.8')
-            set :bundler_version, fetch(:bundler_version, '1.10.6')
+            set :bundler_version, fetch(:bundler_version, '1.14.6')
           end
 
           task :src200railsexpress do
@@ -775,7 +775,7 @@ module Moonshine
               'sudo make install'
             ].join(' && ')
             set :rubygems_version, fetch(:rubygems_version, '2.6.11')
-            set :bundler_version, fetch(:bundler_version, '1.12.5')
+            set :bundler_version, fetch(:bundler_version, '1.14.6')
           end
 
           task :src21railsexpress do
@@ -812,7 +812,7 @@ module Moonshine
               'sudo make install'
             ].join(' && ')
             set :rubygems_version, fetch(:rubygems_version, '2.6.11')
-            set :bundler_version, fetch(:bundler_version, '1.11.2')
+            set :bundler_version, fetch(:bundler_version, '1.14.6')
           end
 
           task :src22 do
@@ -835,7 +835,7 @@ module Moonshine
               'sudo make install'
             ].join(' && ')
             set :rubygems_version, fetch(:rubygems_version, '2.6.11')
-            set :bundler_version, fetch(:bundler_version, '1.13.6')
+            set :bundler_version, fetch(:bundler_version, '1.14.6')
           end
 
           task :src23 do
@@ -859,7 +859,7 @@ module Moonshine
               'sudo make install'
             ].join(' && ')
             set :rubygems_version, fetch(:rubygems_version, '2.6.11')
-            set :bundler_version, fetch(:bundler_version, '1.13.6')
+            set :bundler_version, fetch(:bundler_version, '1.14.6')
           end
 
           task :src24 do
@@ -883,7 +883,7 @@ module Moonshine
               'sudo make install'
             ].join(' && ')
             set :rubygems_version, fetch(:rubygems_version, '2.6.11')
-            set :bundler_version, fetch(:bundler_version, '1.13.6')
+            set :bundler_version, fetch(:bundler_version, '1.14.6')
           end
 
          task :install_rubygems do

--- a/lib/moonshine/capistrano_integration.rb
+++ b/lib/moonshine/capistrano_integration.rb
@@ -862,7 +862,31 @@ module Moonshine
             set :bundler_version, fetch(:bundler_version, '1.13.6')
           end
 
-          task :install_rubygems do
+          task :src24 do
+            remove_ruby_from_apt
+            pv = "2.4.1"
+            p = "ruby-#{pv}"
+            run [
+              'cd /tmp',
+              "sudo rm -rf #{p}* || true",
+              'sudo rm /usr/bin/rake || true',
+              'sudo rm -rf /usr/lib/ruby/gems/1.8 || true',
+              'sudo rm -rf /usr/lib/ruby/gems/1.9.1 || true',
+              'sudo rm -rf /usr/lib/ruby/gems/2.0.0 || true',
+              'sudo rm -rf /usr/lib/ruby/gems/2.1.0 || true',
+              'sudo mkdir -p /usr/lib/ruby/gems/2.2.0/gems || true',
+              "wget -q http://cache.ruby-lang.org/pub/ruby/2.4/#{p}.tar.gz",
+              "tar xzf #{p}.tar.gz",
+              "cd /tmp/#{p}",
+              './configure --prefix=/usr',
+              'make',
+              'sudo make install'
+            ].join(' && ')
+            set :rubygems_version, fetch(:rubygems_version, '2.6.8')
+            set :bundler_version, fetch(:bundler_version, '1.13.6')
+          end
+
+         task :install_rubygems do
             version = fetch(:rubygems_version, '1.8.21')
             run [
               'cd /tmp',

--- a/lib/moonshine/capistrano_integration.rb
+++ b/lib/moonshine/capistrano_integration.rb
@@ -817,7 +817,7 @@ module Moonshine
 
           task :src22 do
             remove_ruby_from_apt
-            pv = "2.2.6"
+            pv = "2.2.7"
             p = "ruby-#{pv}"
             run [
               'cd /tmp',
@@ -840,7 +840,7 @@ module Moonshine
 
           task :src23 do
             remove_ruby_from_apt
-            pv = "2.3.3"
+            pv = "2.3.4"
             p = "ruby-#{pv}"
             run [
               'cd /tmp',

--- a/lib/moonshine/capistrano_integration.rb
+++ b/lib/moonshine/capistrano_integration.rb
@@ -774,7 +774,7 @@ module Moonshine
               'make',
               'sudo make install'
             ].join(' && ')
-            set :rubygems_version, fetch(:rubygems_version, '2.6.4')
+            set :rubygems_version, fetch(:rubygems_version, '2.6.11')
             set :bundler_version, fetch(:bundler_version, '1.12.5')
           end
 
@@ -811,7 +811,7 @@ module Moonshine
               'make',
               'sudo make install'
             ].join(' && ')
-            set :rubygems_version, fetch(:rubygems_version, '2.6.2')
+            set :rubygems_version, fetch(:rubygems_version, '2.6.11')
             set :bundler_version, fetch(:bundler_version, '1.11.2')
           end
 
@@ -834,7 +834,7 @@ module Moonshine
               'make',
               'sudo make install'
             ].join(' && ')
-            set :rubygems_version, fetch(:rubygems_version, '2.6.8')
+            set :rubygems_version, fetch(:rubygems_version, '2.6.11')
             set :bundler_version, fetch(:bundler_version, '1.13.6')
           end
 
@@ -858,7 +858,7 @@ module Moonshine
               'make',
               'sudo make install'
             ].join(' && ')
-            set :rubygems_version, fetch(:rubygems_version, '2.6.8')
+            set :rubygems_version, fetch(:rubygems_version, '2.6.11')
             set :bundler_version, fetch(:bundler_version, '1.13.6')
           end
 
@@ -882,7 +882,7 @@ module Moonshine
               'make',
               'sudo make install'
             ].join(' && ')
-            set :rubygems_version, fetch(:rubygems_version, '2.6.8')
+            set :rubygems_version, fetch(:rubygems_version, '2.6.11')
             set :bundler_version, fetch(:bundler_version, '1.13.6')
           end
 


### PR DESCRIPTION
Updates Ruby 2.2 and 2.3, adds support for Ruby 2.4.  Updates RubyGems to 2.6.11 and Bundler to 1.14.6.