### PR TITLE
A change in rails 4+ calls freeze forcing us not to be able to modify…

### DIFF
--- a/lib/generators/moonshine/moonshine_generator.rb
+++ b/lib/generators/moonshine/moonshine_generator.rb
@@ -102,7 +102,7 @@ protected
   end
 
   def ruby
-    options[:ruby] ||= "src23"
+    @ruby ||= (options[:ruby] || "src23")
   end
 
   def user


### PR DESCRIPTION
… the hash directly, so the changeset is now stored in an instance variable

While getting the moonshine test app running, ran into a snag todo with freeze forcing a hash to not be modifiable directly.

This was the error message I were receiving:
[freeze_debug_log.txt](https://github.com/railsmachine/moonshine/files/1004740/freeze_debug_log.txt)